### PR TITLE
Add pre-commit setup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+      - id: black
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.4
+    hooks:
+      - id: ruff
+        args: ["--fix"]
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.8.0
+    hooks:
+      - id: mypy

--- a/README.md
+++ b/README.md
@@ -26,3 +26,19 @@ The game requires several Python packages. Install them using:
 
 ```bash
 pip install textual rich pydantic numpy tinydb
+```
+
+## Development
+
+This project uses `pre-commit` to run formatting, linting and type checks. Set it up with:
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+Run all checks manually using:
+
+```bash
+pre-commit run --all-files
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,3 +10,15 @@ dependencies = [
     "textual>=3.3.0",
     "tinydb>=4.8.2",
 ]
+
+[tool.black]
+line-length = 88
+target-version = ['py311']
+
+[tool.ruff]
+line-length = 88
+target-version = 'py311'
+
+[tool.mypy]
+python_version = '3.11'
+strict = true


### PR DESCRIPTION
## Summary
- add pre-commit config with `black`, `ruff` and `mypy`
- configure tools in `pyproject.toml`
- document pre-commit installation in the README

## Testing
- `pre-commit run --files README.md pyproject.toml .pre-commit-config.yaml`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_684bd6b2cc988331882f09308965f929