### PR TITLE
Add periodic UI updates and key-based view switching

### DIFF
--- a/pyaurora4x/ui/main_app.py
+++ b/pyaurora4x/ui/main_app.py
@@ -203,10 +203,10 @@ class PyAurora4XApp(App):
         """Initialize the application after mounting."""
         self.title = "PyAurora 4X - Terminal Space Strategy"
         self.sub_title = "A Python-based 4X game with realistic orbital mechanics"
-        
-        # Define custom CSS as a class attribute instead of runtime update
-        pass
-        
+
+        # Periodic UI refresh so widgets stay up to date
+        self.set_interval(1.0, self._on_tick)
+
         logger.info("PyAurora 4X application started")
     
     def on_ready(self) -> None:
@@ -253,7 +253,9 @@ class PyAurora4XApp(App):
         system_view = self.query_one("#system_view", StarSystemView)
         if self.simulation.star_systems:
             first_system = list(self.simulation.star_systems.values())[0]
-            system_view.update_system(first_system)
+            system_fleets = [f for f in self.simulation.fleets.values() if f.system_id == first_system.id]
+            system_view.update_system(first_system, system_fleets)
+        system_view.refresh_positions()
         
         # Update fleet panel
         fleet_panel = self.query_one("#fleet_view", FleetPanel)
@@ -261,11 +263,13 @@ class PyAurora4XApp(App):
         if player_empire:
             fleets = [self.simulation.get_fleet(fid) for fid in player_empire.fleets if self.simulation.get_fleet(fid) is not None]
             fleet_panel.update_fleets(fleets)
+        fleet_panel.refresh()
         
         # Update research panel
         research_panel = self.query_one("#research_view", ResearchPanel)
         if player_empire:
             research_panel.update_empire(player_empire)
+        research_panel.refresh()
         
         # Update empire stats
         empire_stats = self.query_one("#empire_stats", EmpireStatsWidget)
@@ -278,6 +282,19 @@ class PyAurora4XApp(App):
             self.simulation.current_time,
             self.simulation.is_paused
         )
+
+    def _on_tick(self) -> None:
+        """Periodic refresh callback."""
+        if not self.simulation:
+            return
+
+        if not self.simulation.is_paused:
+            current_time = self.simulation.current_time
+            if current_time - self.last_auto_save > self.auto_save_interval:
+                self.action_save_game()
+                self.last_auto_save = current_time
+
+        self._update_all_widgets()
     
     def on_time_control_event(self, event: TimeControlEvent) -> None:
         """Handle time control events."""
@@ -383,8 +400,26 @@ class PyAurora4XApp(App):
     
     def on_key(self, event: events.Key) -> None:
         """Handle key presses."""
-        # Let the binding system handle most keys
-        pass
+        key = event.key
+        if key == "1":
+            self.action_show_systems()
+        elif key == "2":
+            self.action_show_fleets()
+        elif key == "3":
+            self.action_show_research()
+        elif key == "q":
+            self.action_quit()
+        elif key == "s":
+            self.action_save_game()
+        elif key == "l":
+            self.action_load_game()
+        elif key == "h":
+            self.action_show_help()
+        elif key == "space":
+            self.action_toggle_pause()
+        else:
+            return
+        event.prevent_default()
     
     async def action_quit(self) -> None:
         """Quit the application."""

--- a/pyaurora4x/ui/widgets/fleet_panel.py
+++ b/pyaurora4x/ui/widgets/fleet_panel.py
@@ -285,6 +285,10 @@ class FleetPanel(Static):
             if self.current_fleet:
                 self._update_fleet_details()
 
+    def refresh(self) -> None:
+        """Refresh fleet information."""
+        self._update_display()
+
 
 class FleetCommandEvent:
     """Event for fleet commands."""

--- a/pyaurora4x/ui/widgets/research_panel.py
+++ b/pyaurora4x/ui/widgets/research_panel.py
@@ -378,6 +378,10 @@ class ResearchPanel(Static):
             if self.current_tech:
                 self._update_tech_details()
 
+    def refresh(self) -> None:
+        """Refresh research information."""
+        self._update_display()
+
 
 class ResearchCommandEvent:
     """Event for research commands."""

--- a/pyaurora4x/ui/widgets/star_system_view.py
+++ b/pyaurora4x/ui/widgets/star_system_view.py
@@ -54,6 +54,11 @@ class StarSystemView(Static):
         self.system_fleets = fleets or []
         self._calculate_scale()
         self._render_system()
+
+    def refresh_positions(self) -> None:
+        """Refresh planet and fleet positions."""
+        if self.system:
+            self._render_system()
     
     def _calculate_scale(self) -> None:
         """Calculate the scale factor for display."""


### PR DESCRIPTION
## Summary
- refresh UI every second to keep planet positions and panels updated
- switch between system, fleet and research views using keyboard shortcuts
- expose `refresh` helpers in star system, fleet and research widgets

## Testing
- `pytest -q` *(fails: AssertionError in `test_eccentric_orbit` and `test_star_system_generation`)*
- `python main.py --test`

------
https://chatgpt.com/codex/tasks/task_e_684bd6b689b08331811dbd0bd94da0fd