### PR TITLE
Add tech tree research management and persistence

### DIFF
--- a/pyaurora4x/data/save_manager.py
+++ b/pyaurora4x/data/save_manager.py
@@ -8,6 +8,7 @@ import json
 import os
 from typing import Dict, Any, List, Optional
 from datetime import datetime
+from enum import Enum
 from pathlib import Path
 import logging
 
@@ -391,7 +392,9 @@ class SaveManager:
     
     def _json_serializer(self, obj):
         """Custom JSON serializer for complex objects."""
-        if hasattr(obj, 'dict'):
+        if isinstance(obj, Enum):
+            return obj.value
+        elif hasattr(obj, 'dict'):
             return obj.dict()
         elif hasattr(obj, '__dict__'):
             return obj.__dict__

--- a/pyaurora4x/engine/orbital_mechanics.py
+++ b/pyaurora4x/engine/orbital_mechanics.py
@@ -151,17 +151,20 @@ class OrbitalMechanics:
                 planet_data = system_data['planets'][i]
                 
                 # Calculate mean motion (radians per second)
-                period_seconds = planet_data['orbital_period'] * 365.25 * 24 * 3600
+                period_seconds = planet_data['orbital_period']
                 mean_motion = 2 * np.pi / period_seconds
                 
                 # Calculate mean anomaly at current time
                 mean_anomaly = (mean_motion * current_time) % (2 * np.pi)
                 
-                # For simplicity, assume circular orbits (e = 0)
-                true_anomaly = mean_anomaly
-                
-                # Calculate position in orbital plane
-                r = planet_data['orbital_distance'] * 149597870.7  # Convert AU to km
+                e = planet_data.get('eccentricity', 0.0)
+                E = mean_anomaly
+                for _ in range(5):
+                    E = mean_anomaly + e * np.sin(E)
+                a = planet_data['orbital_distance'] * 149597870.7
+                r = a * (1 - e * np.cos(E))
+                true_anomaly = 2 * np.arctan2(np.sqrt(1 + e) * np.sin(E / 2),
+                                             np.sqrt(1 - e) * np.cos(E / 2))
                 x = r * np.cos(true_anomaly)
                 y = r * np.sin(true_anomaly)
                 z = 0.0

--- a/pyaurora4x/ui/main_app.py
+++ b/pyaurora4x/ui/main_app.py
@@ -265,6 +265,7 @@ class PyAurora4XApp(App):
         # Update research panel
         research_panel = self.query_one("#research_view", ResearchPanel)
         if player_empire:
+            research_panel.tech_manager = self.simulation.tech_manager
             research_panel.update_empire(player_empire)
         
         # Update empire stats

--- a/tests/test_research.py
+++ b/tests/test_research.py
@@ -1,0 +1,41 @@
+from pyaurora4x.engine.simulation import GameSimulation
+from pyaurora4x.data.save_manager import SaveManager
+
+
+def test_research_completion():
+    sim = GameSimulation()
+    sim.initialize_new_game(num_systems=1, num_empires=1)
+    empire = sim.get_player_empire()
+
+    tech_id = "basic_propulsion"
+    empire.current_research = tech_id
+    empire.research_points = 0
+    tech = empire.technologies[tech_id]
+
+    sim.advance_time(tech.research_cost)
+
+    assert tech.is_researched
+    assert empire.current_research is None
+
+
+def test_research_persistence(tmp_path):
+    sim = GameSimulation()
+    sim.initialize_new_game(num_systems=1, num_empires=1)
+    empire = sim.get_player_empire()
+
+    tech_id = "basic_sensors"
+    empire.current_research = tech_id
+    empire.research_points = 0
+    tech = empire.technologies[tech_id]
+
+    sim.advance_time(tech.research_cost)
+
+    manager = SaveManager(save_directory=str(tmp_path))
+    manager.use_tinydb = False
+    save_file = manager.save_game(sim.get_game_state(), "save1")
+    loaded = manager.load_game(save_file)
+
+    sim2 = GameSimulation()
+    sim2.load_game_state(loaded)
+    empire2 = sim2.get_player_empire()
+    assert empire2.technologies[tech_id].is_researched


### PR DESCRIPTION
## Summary
- load TechTreeManager in `GameSimulation`
- give empires copies of available technologies
- process research progress during time advancement
- serialize enums in SaveManager
- use tech manager in `ResearchPanel`
- support eccentric orbits and safe player empire creation
- add tests for research completion and persistence

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bd6b885848331a58ddb16d8332b08