### PR TITLE
Add MIT license file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024
+Copyright (c) 2025 PyAurora4X
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -81,5 +81,5 @@ markdown files from both that index and this README when appropriate.
 
 ## License
 
-PyAurora 4X is released under the [MIT License](LICENSE).
+This project is licensed under the [MIT License](LICENSE).
 


### PR DESCRIPTION
## Summary
- add MIT license text at repo root
- revise README with a short License section linking the file

## Testing
- `pip install numpy pydantic textual tinydb rebound pytest`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c7efe00d0833181c4e929479e09f1