### PR TITLE
Add SaveManager export/import test

### DIFF
--- a/tests/test_save_manager_export.py
+++ b/tests/test_save_manager_export.py
@@ -1,55 +1,40 @@
 import json
-
 import duckdb
-
-import pyaurora4x.data.save_manager as sm
 from pyaurora4x.data.save_manager import SaveManager
 
 
-def _setup_json_manager(tmp_path, monkeypatch):
-    monkeypatch.setattr(sm, "TINYDB_AVAILABLE", False)
-    monkeypatch.setattr(sm, "DUCKDB_AVAILABLE", False)
-    return SaveManager(save_directory=str(tmp_path), use_duckdb=False)
+def test_export_import_json_and_duckdb(tmp_path):
+    """Save a game then export and re-import using both formats."""
+    manager = SaveManager(save_directory=str(tmp_path), use_duckdb=False)
 
+    data = {"value": 42}
+    manager.save_game(data, "test_save")
 
-def test_export_import_json(tmp_path, monkeypatch):
-    manager = _setup_json_manager(tmp_path, monkeypatch)
+    # Export to JSON and re-import
+    json_export = tmp_path / "export.json"
+    manager.export_save("test_save", str(json_export))
+    assert json_export.exists()
 
-    data = {"value": 123}
-    manager.save_game(data, "save1")
+    imported_json = manager.import_save(str(json_export), "imported_json")
+    assert manager.load_game(imported_json) == data
 
-    export_file = tmp_path / "export.json"
-    manager.export_save("save1", str(export_file))
-    assert export_file.exists()
+    # Export to DuckDB and re-import
+    duckdb_export = tmp_path / "export.duckdb"
+    manager.export_save("test_save", str(duckdb_export))
+    assert duckdb_export.exists()
 
-    imported_name = manager.import_save(str(export_file), "imported_json")
-    loaded = manager.load_game(imported_name)
-    assert loaded == data
-
-
-def test_export_import_duckdb(tmp_path, monkeypatch):
-    manager = _setup_json_manager(tmp_path, monkeypatch)
-
-    data = {"value": 321}
-    manager.save_game(data, "save1")
-
-    export_file = tmp_path / "export.duckdb"
-    manager.export_save("save1", str(export_file))
-    assert export_file.exists()
-
-    with duckdb.connect(str(export_file)) as conn:
+    with duckdb.connect(str(duckdb_export)) as conn:
         row = conn.execute(
             "SELECT game_state FROM exports WHERE export_name = ?",
-            ["save1"],
+            ["test_save"],
         ).fetchone()
     assert row is not None
     exported_state = json.loads(row[0])
     assert exported_state == data
 
-    json_file = tmp_path / "export_from_duckdb.json"
-    with open(json_file, "w") as f:
+    json_from_duckdb = tmp_path / "from_duckdb.json"
+    with open(json_from_duckdb, "w") as f:
         json.dump({"game_state": exported_state}, f)
 
-    imported_name = manager.import_save(str(json_file), "imported_duckdb")
-    loaded = manager.load_game(imported_name)
-    assert loaded == data
+    imported_duckdb = manager.import_save(str(json_from_duckdb), "imported_duckdb")
+    assert manager.load_game(imported_duckdb) == data


### PR DESCRIPTION
## Summary
- verify SaveManager export/import workflow for both JSON and DuckDB

## Testing
- `pip install numpy pydantic textual tinydb rebound pytest duckdb`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c7ef76a1c83319421e7417a42771b