### PR TITLE
Update test install instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ Install the dependencies listed in `pyproject.toml` using pip, then run the test
 suite:
 
 ```bash
-pip install numpy pydantic textual tinydb rebound pytest
+pip install numpy "pydantic>=2.11.5" textual tinydb rebound duckdb pytest
 pytest -q
 ```
 


### PR DESCRIPTION
## Summary
- update Running Tests instructions in AGENTS.md to include duckdb and new pydantic pin

## Testing
- `pip install numpy "pydantic>=2.11.5" textual tinydb rebound duckdb pytest`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c84cd50f8833195e2aed317de29b5