### PR TITLE
Use model_dump for model serialization

### DIFF
--- a/pyaurora4x/data/save_manager.py
+++ b/pyaurora4x/data/save_manager.py
@@ -553,8 +553,8 @@ class SaveManager:
         """Custom JSON serializer for complex objects."""
         if isinstance(obj, Enum):
             return obj.value
-        elif hasattr(obj, "dict"):
-            return obj.dict()
+        elif hasattr(obj, "model_dump"):
+            return obj.model_dump()
         elif hasattr(obj, "__dict__"):
             return obj.__dict__
         elif isinstance(obj, datetime):

--- a/pyaurora4x/engine/simulation.py
+++ b/pyaurora4x/engine/simulation.py
@@ -63,7 +63,7 @@ class GameSimulation:
         """Create a fresh copy of all technologies for a new empire."""
         techs = {}
         for tech_id, tech in self.tech_manager.get_all_technologies().items():
-            techs[tech_id] = Technology(**tech.dict())
+            techs[tech_id] = Technology(**tech.model_dump())
         return techs
     
     def initialize_new_game(self, num_systems: int = 3, num_empires: int = 2) -> None:
@@ -365,9 +365,9 @@ class GameSimulation:
         return {
             "current_time": self.current_time,
             "game_start_time": self.game_start_time.isoformat(),
-            "empires": {id: empire.dict() for id, empire in self.empires.items()},
-            "star_systems": {id: system.dict() for id, system in self.star_systems.items()},
-            "fleets": {id: fleet.dict() for id, fleet in self.fleets.items()},
+            "empires": {id: empire.model_dump() for id, empire in self.empires.items()},
+            "star_systems": {id: system.model_dump() for id, system in self.star_systems.items()},
+            "fleets": {id: fleet.model_dump() for id, fleet in self.fleets.items()},
         }
     
     def load_game_state(self, state: Dict[str, Any]) -> None:

--- a/pyaurora4x/ui/widgets/research_panel.py
+++ b/pyaurora4x/ui/widgets/research_panel.py
@@ -75,7 +75,7 @@ class ResearchPanel(Static):
         # Ensure empire has technologies loaded
         if not self.current_empire.technologies and self.tech_manager:
             self.current_empire.technologies = {
-                tid: Technology(**t.dict())
+                tid: Technology(**t.model_dump())
                 for tid, t in self.tech_manager.get_all_technologies().items()
             }
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -81,7 +81,7 @@ class TestTechnology:
             research_cost=100
         )
         
-        data = tech.dict()
+        data = tech.model_dump()
         assert data["id"] == "test_tech"
         assert data["name"] == "Test Technology"
         assert data["research_cost"] == 100
@@ -254,7 +254,7 @@ class TestEmpire:
             home_planet_id="home_planet"
         )
         
-        data = empire.dict()
+        data = empire.model_dump()
         assert data["name"] == "Test Empire"
         assert data["home_system_id"] == "home_system"
         assert data["is_player"] is False


### PR DESCRIPTION
## Summary
- swap deprecated `.dict()` calls for `.model_dump()` across the codebase
- update serializer helper in SaveManager
- refresh research panel to use `.model_dump()` when loading technologies
- update unit tests accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c84c94cec8331b970dd59fdc7d6ba