### PR TITLE
Add SaveManager export/import tests

### DIFF
--- a/tests/test_save_manager_export.py
+++ b/tests/test_save_manager_export.py
@@ -1,40 +1,49 @@
+"""Tests for exporting and importing saves."""
+
 import json
 import duckdb
+
 from pyaurora4x.data.save_manager import SaveManager
 
 
-def test_export_import_json_and_duckdb(tmp_path):
-    """Save a game then export and re-import using both formats."""
+def test_export_import_json(tmp_path):
+    """Save a game, export to JSON, then import back."""
     manager = SaveManager(save_directory=str(tmp_path), use_duckdb=False)
 
     data = {"value": 42}
     manager.save_game(data, "test_save")
 
-    # Export to JSON and re-import
-    json_export = tmp_path / "export.json"
-    manager.export_save("test_save", str(json_export))
-    assert json_export.exists()
+    export_file = tmp_path / "export.json"
+    manager.export_save("test_save", str(export_file))
+    assert export_file.exists()
 
-    imported_json = manager.import_save(str(json_export), "imported_json")
-    assert manager.load_game(imported_json) == data
+    imported_name = manager.import_save(str(export_file), "imported_json")
+    assert manager.load_game(imported_name) == data
 
-    # Export to DuckDB and re-import
-    duckdb_export = tmp_path / "export.duckdb"
-    manager.export_save("test_save", str(duckdb_export))
-    assert duckdb_export.exists()
 
-    with duckdb.connect(str(duckdb_export)) as conn:
+def test_export_import_duckdb(tmp_path):
+    """Save a game, export to DuckDB, then import back."""
+    manager = SaveManager(save_directory=str(tmp_path), use_duckdb=False)
+
+    data = {"value": 42}
+    manager.save_game(data, "test_save")
+
+    duckdb_file = tmp_path / "export.duckdb"
+    manager.export_save("test_save", str(duckdb_file))
+    assert duckdb_file.exists()
+
+    with duckdb.connect(str(duckdb_file)) as conn:
         row = conn.execute(
             "SELECT game_state FROM exports WHERE export_name = ?",
             ["test_save"],
         ).fetchone()
+
     assert row is not None
     exported_state = json.loads(row[0])
-    assert exported_state == data
 
-    json_from_duckdb = tmp_path / "from_duckdb.json"
-    with open(json_from_duckdb, "w") as f:
-        json.dump({"game_state": exported_state}, f)
+    json_file = tmp_path / "from_duckdb.json"
+    json_file.write_text(json.dumps({"game_state": exported_state}))
 
-    imported_duckdb = manager.import_save(str(json_from_duckdb), "imported_duckdb")
-    assert manager.load_game(imported_duckdb) == data
+    imported_name = manager.import_save(str(json_file), "imported_duckdb")
+    assert manager.load_game(imported_name) == data
+


### PR DESCRIPTION
## Summary
- expand SaveManager tests
- verify exporting to JSON and DuckDB and reimporting via `import_save`

## Testing
- `pip install numpy "pydantic>=2.11.5" textual tinydb rebound duckdb pytest`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c8a96ebbc8331a896f331e880ab32