### PR TITLE
Update docs section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,17 +94,22 @@ and type-check with **mypy** every time you commit.
 
 ## Documentation
 
-Additional markdown resources are stored in the `docs` directory.
-See [docs/README.md](docs/README.md) for an overview of available files,
-a table of contents, and instructions on contributing new documentation.
-Remember to add new markdown files to that index and mention them here when appropriate.
+All written guides and reference material live in the `docs/` directory.  It
+acts as the central hub for design notes, usage instructions, and other
+supplementary information.  Begin with
+[docs/README.md](docs/README.md) which serves as the index and explains how to
+contribute new documents.
 
-Additional markdown documents are stored in the `docs` directory.
-See [docs/README.md](docs/README.md) for an index of available files and
-guidelines on contributing new documentation. Remember to link any new
-markdown files from both that index and this README when appropriate.
-For a summary of project goals and directory layout, see
-[docs/design_overview.md](docs/design_overview.md).
+### Available Guides
+
+- [docs/README.md](docs/README.md) – Documentation index and contribution
+  guidelines.
+- [docs/design_overview.md](docs/design_overview.md) – Summary of project goals
+  and folder structure.
+- [docs/gameplay_guide.md](docs/gameplay_guide.md) – Gameplay instructions
+  *(planned)*.
+- [docs/contributing.md](docs/contributing.md) – Developer contribution guide
+  *(planned)*.
 
 
 ## License


### PR DESCRIPTION
## Summary
- clarify the purpose of the `docs/` directory
- list current and planned documentation links

## Testing
- `pip install numpy "pydantic>=2.11.5" textual tinydb rebound duckdb pytest`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c8a914c0c8331aea7adfa4f22e156