### PR TITLE
Add contributing guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ contribute new documents.
 - [docs/README.md](docs/README.md) – Documentation index and contribution guidelines.
 - [docs/design_overview.md](docs/design_overview.md) – Summary of project goals and folder structure.
 - [docs/gameplay_guide.md](docs/gameplay_guide.md) – Gameplay instructions and fleet movement mechanics.
-- [docs/contributing.md](docs/contributing.md) – Developer contribution guide *(planned)*.
+- [docs/contributing.md](docs/contributing.md) – Developer contribution guide.
 
 
 ## License

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ for documentation and as a guide when adding new files.
 - [Documentation Overview](README.md)
 - [Design Overview](design_overview.md)
 - [Gameplay Guide](gameplay_guide.md)
+- [Contribution Guide](contributing.md)
 
 
 ## Contributing New Documentation

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,39 @@
+# Contributing Guide
+
+This document explains how to prepare your environment, follow the project's coding style, and verify your changes with tests.
+
+## Coding Style
+
+- Format code with **black** using a line length of 88 characters.
+- Lint the project with **ruff** for standard Python style and import ordering.
+- Type-check new code with **mypy**.
+
+All these tools run automatically via the pre-commit hooks described below.
+
+## Pre-commit Workflow
+
+1. Install the [`pre-commit`](https://pre-commit.com) tool:
+   ```bash
+   pip install pre-commit
+   ```
+2. Install the hooks for this repository:
+   ```bash
+   pre-commit install
+   ```
+3. The hooks will run **black**, **ruff**, and **mypy** each time you commit. You can manually run them on all files with:
+   ```bash
+   pre-commit run --all-files
+   ```
+
+Keeping the hooks active ensures that every commit adheres to the project's coding standards.
+
+## Running Tests
+
+Before submitting changes, install the project's dependencies and execute the test suite:
+
+```bash
+pip install numpy "pydantic>=2.11.5" textual tinydb rebound duckdb pytest
+pytest -q
+```
+
+All tests should pass before opening a pull request.


### PR DESCRIPTION
## Summary
- add developer contribution guide
- link new guide from docs/README table of contents
- update README reference to the guide

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c94dd29208331b736a1168daf6831