### PR TITLE
Fix empire age display

### DIFF
--- a/pyaurora4x/ui/main_app.py
+++ b/pyaurora4x/ui/main_app.py
@@ -285,7 +285,9 @@ class PyAurora4XApp(App):
         # Update empire stats
         empire_stats = self.query_one("#empire_stats", EmpireStatsWidget)
         if player_empire:
-            empire_stats.update_empire(player_empire)
+            empire_stats.update_empire(
+                player_empire, self.simulation.current_time
+            )
         
         # Update time controls
         time_controls = self.query_one("#time_controls", TimeControlWidget)

--- a/pyaurora4x/ui/widgets/empire_stats.py
+++ b/pyaurora4x/ui/widgets/empire_stats.py
@@ -27,6 +27,7 @@ class EmpireStatsWidget(Static):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.current_empire: Optional[Empire] = None
+        self.current_time: float = 0.0
     
     def compose(self) -> ComposeResult:
         """Compose the empire stats layout."""
@@ -40,7 +41,7 @@ class EmpireStatsWidget(Static):
                 yield Static("", id="empire_military", classes="info-section")
                 yield Static("", id="empire_colonies", classes="info-section")
     
-    def update_empire(self, empire: Empire) -> None:
+    def update_empire(self, empire: Empire, current_time: Optional[float] = None) -> None:
         """
         Update the displayed empire.
         
@@ -48,6 +49,8 @@ class EmpireStatsWidget(Static):
             empire: Empire to display statistics for
         """
         self.current_empire = empire
+        if current_time is not None:
+            self.current_time = current_time
         self._update_all_sections()
     
     def _update_all_sections(self) -> None:
@@ -87,7 +90,10 @@ class EmpireStatsWidget(Static):
         lines.append(f"Culture: {empire.culture}")
         
         if empire.established_date > 0:
-            age = format_time(empire.established_date)
+            age_seconds = self.current_time - empire.established_date
+            if age_seconds < 0:
+                age_seconds = 0.0
+            age = format_time(age_seconds)
             lines.append(f"Age: {age}")
         
         lines.append(f"Home System: {empire.home_system_id}")

--- a/tests/test_empire_stats_widget.py
+++ b/tests/test_empire_stats_widget.py
@@ -1,0 +1,26 @@
+import types
+from pyaurora4x.ui.widgets.empire_stats import EmpireStatsWidget
+from pyaurora4x.core.models import Empire
+from pyaurora4x.core.utils import format_time
+
+
+def test_empire_age_calculation(monkeypatch):
+    widget = EmpireStatsWidget()
+    empire = Empire(
+        name="Test", home_system_id="sys", home_planet_id="planet", established_date=100.0
+    )
+    widget.current_empire = empire
+    widget.current_time = 200.0
+
+    captured = {}
+
+    class Dummy:
+        def update(self, text: str) -> None:
+            captured["text"] = text
+
+    monkeypatch.setattr(widget, "query_one", lambda *args, **kwargs: Dummy())
+
+    widget._update_basic_info()
+
+    expected_age = format_time(100.0)
+    assert f"Age: {expected_age}" in captured.get("text", "")


### PR DESCRIPTION
## Summary
- compute empire age from current time in EmpireStatsWidget
- pass the current game time to EmpireStatsWidget
- test that empire age uses difference between current time and founding date

## Testing
- `pip install numpy "pydantic>=2.11.5" textual tinydb rebound duckdb pytest`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cc2117a9c8331b5dd0d075d2de86f