### PR TITLE
Show ETA countdown in fleet panel

### DIFF
--- a/pyaurora4x/ui/main_app.py
+++ b/pyaurora4x/ui/main_app.py
@@ -272,7 +272,7 @@ class PyAurora4XApp(App):
         player_empire = self.simulation.get_player_empire()
         if player_empire:
             fleets = [self.simulation.get_fleet(fid) for fid in player_empire.fleets if self.simulation.get_fleet(fid) is not None]
-            fleet_panel.update_fleets(fleets)
+            fleet_panel.update_fleets(fleets, self.simulation.current_time)
         fleet_panel.refresh()
         
         # Update research panel


### PR DESCRIPTION
## Summary
- display ETA as remaining time in `FleetPanel`
- pass current simulation time when updating fleets

## Testing
- `pip install numpy "pydantic>=2.11.5" textual tinydb rebound duckdb pytest`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cc20bd05083319be71bdbc750bba3