### PR TITLE
Handle negative keep_count in save cleanup

### DIFF
--- a/pyaurora4x/data/save_manager.py
+++ b/pyaurora4x/data/save_manager.py
@@ -527,20 +527,25 @@ class SaveManager:
         Clean up old save files, keeping only the most recent ones.
 
         Args:
-            keep_count: Number of saves to keep
+            keep_count: Number of saves to keep. Values less than or equal to
+                zero will remove all saves.
 
         Returns:
             Number of saves deleted
         """
         saves = self.list_saves()
 
-        if len(saves) <= keep_count:
+        # Clamp keep_count to a minimum of 0 to avoid negative slicing
+        keep_count = max(0, keep_count)
+
+        if keep_count <= 0:
+            saves_to_delete = saves
+        elif len(saves) <= keep_count:
             return 0
+        else:
+            saves_to_delete = saves[keep_count:]
 
-        # Delete oldest saves
-        saves_to_delete = saves[keep_count:]
         deleted_count = 0
-
         for save_metadata in saves_to_delete:
             save_name = save_metadata["save_name"]
             if self.delete_save(save_name):

--- a/tests/test_save_manager_additional.py
+++ b/tests/test_save_manager_additional.py
@@ -28,6 +28,24 @@ def test_cleanup_old_saves(tmp_path, monkeypatch):
         assert len(manager.list_saves()) == 10
 
 
+def test_cleanup_all_when_keep_count_zero_or_negative(tmp_path, monkeypatch):
+    for backend in ["json", "tinydb", "duckdb"]:
+        manager = create_manager(tmp_path / f"zero_{backend}", backend, monkeypatch)
+        for i in range(5):
+            manager.save_game({"idx": i}, f"save_zero_{i}")
+        assert len(manager.list_saves()) == 5
+        deleted = manager.cleanup_old_saves(keep_count=0)
+        assert deleted == 5
+        assert len(manager.list_saves()) == 0
+
+        for i in range(3):
+            manager.save_game({"idx": i}, f"save_neg_{i}")
+        assert len(manager.list_saves()) == 3
+        deleted = manager.cleanup_old_saves(keep_count=-2)
+        assert deleted == 3
+        assert len(manager.list_saves()) == 0
+
+
 def test_get_save_info_json_and_tinydb(tmp_path, monkeypatch):
     for backend in ["json", "tinydb"]:
         manager = create_manager(tmp_path / backend, backend, monkeypatch)


### PR DESCRIPTION
## Summary
- handle keep_count<=0 in cleanup_old_saves
- clamp keep_count to avoid negative slicing
- test cleanup when keep_count is zero or negative for all backends

## Testing
- `pip install numpy "pydantic>=2.11.5" textual tinydb rebound duckdb pytest`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cc9e599288331a3b4b29b1cf00221