### PR TITLE
Add PYAURORA_SAVE_DIR override

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ manager = SaveManager(use_duckdb=True)
 manager = SaveManager(use_duckdb=False)
 ```
 
+You can change the default save directory by setting the
+`PYAURORA_SAVE_DIR` environment variable. If `save_directory` is not
+provided, `SaveManager` will use this path:
+
+```bash
+export PYAURORA_SAVE_DIR=/path/to/saves
+```
+
 ### Running the Game
 
 Launch the main interface with:

--- a/pyaurora4x/data/save_manager.py
+++ b/pyaurora4x/data/save_manager.py
@@ -5,6 +5,7 @@ Handles game state serialization and persistence using DuckDB, TinyDB or JSON.
 """
 
 import json
+import os
 from typing import Any, Dict, List, Optional
 from datetime import datetime
 from enum import Enum
@@ -39,16 +40,21 @@ class SaveManager:
     """
 
     def __init__(
-        self, save_directory: str = "saves", *, use_duckdb: Optional[bool] = None
+        self, save_directory: Optional[str] = None, *, use_duckdb: Optional[bool] = None
     ):
         """
         Initialize the save manager.
 
         Args:
-            save_directory: Directory to store save files
+            save_directory: Directory to store save files. If ``None`` the
+                ``PYAURORA_SAVE_DIR`` environment variable is checked and used
+                when set. Otherwise defaults to ``"saves"``.
             use_duckdb: Force use of DuckDB if True or disable if False. If None,
                 uses DuckDB when available.
         """
+        if save_directory is None:
+            save_directory = os.getenv("PYAURORA_SAVE_DIR", "saves")
+
         self.save_directory = Path(save_directory)
         self.save_directory.mkdir(exist_ok=True)
 

--- a/tests/test_save_manager.py
+++ b/tests/test_save_manager.py
@@ -55,3 +55,11 @@ def test_list_and_load_specific_save(tmp_path):
 
     loaded = manager.load_game("second")
     assert loaded == data2
+
+
+def test_environment_override(tmp_path, monkeypatch):
+    env_path = tmp_path / "env_saves"
+    monkeypatch.setenv("PYAURORA_SAVE_DIR", str(env_path))
+    manager = SaveManager()
+    assert manager.save_directory == env_path
+    _run_cycle(manager, "env_save")


### PR DESCRIPTION
## Summary
- allow specifying the default save path via `PYAURORA_SAVE_DIR`
- document the environment variable in README
- test that the env var overrides the default directory

## Testing
- `pip install numpy "pydantic>=2.11.5" textual tinydb rebound duckdb pytest`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cf157ce308331b9493775e7f6fb1f