### PR TITLE
Show recent fleet events in stats widget

### DIFF
--- a/pyaurora4x/core/events.py
+++ b/pyaurora4x/core/events.py
@@ -320,14 +320,30 @@ class EventManager:
             List of pending notifications
         """
         notifications = []
-        
+
         for event in self.event_queue:
-            if (event.category == EventCategory.NOTIFICATION and 
+            if (event.category == EventCategory.NOTIFICATION and
                 event.requires_attention and
                 (event.empire_id == empire_id or event.empire_id is None)):
                 notifications.append(event)
-        
+
         return notifications
+
+    def get_recent_events(
+        self,
+        empire_id: str,
+        category: EventCategory,
+        limit: int = 5,
+    ) -> List[GameEvent]:
+        """Get the most recent processed events for an empire and category."""
+
+        events = [
+            e
+            for e in self.processed_events
+            if e.category == category and (e.empire_id == empire_id or e.empire_id is None)
+        ]
+        events.sort(key=lambda e: e.timestamp, reverse=True)
+        return events[:limit]
     
     def clear_processed_events(self, older_than: Optional[float] = None) -> int:
         """

--- a/pyaurora4x/ui/main_app.py
+++ b/pyaurora4x/ui/main_app.py
@@ -285,6 +285,7 @@ class PyAurora4XApp(App):
         # Update empire stats
         empire_stats = self.query_one("#empire_stats", EmpireStatsWidget)
         if player_empire:
+            empire_stats.event_manager = self.simulation.event_manager
             empire_stats.update_empire(
                 player_empire, self.simulation.current_time
             )

--- a/pyaurora4x/ui/widgets/empire_stats.py
+++ b/pyaurora4x/ui/widgets/empire_stats.py
@@ -12,6 +12,7 @@ from textual.reactive import reactive
 
 from pyaurora4x.core.models import Empire
 from pyaurora4x.core.utils import format_time
+from pyaurora4x.core.events import EventManager, EventCategory
 
 
 class EmpireStatsWidget(Static):
@@ -24,8 +25,9 @@ class EmpireStatsWidget(Static):
     
     empire = reactive(None)
     
-    def __init__(self, **kwargs):
+    def __init__(self, event_manager: Optional[EventManager] = None, **kwargs):
         super().__init__(**kwargs)
+        self.event_manager: Optional[EventManager] = event_manager
         self.current_empire: Optional[Empire] = None
         self.current_time: float = 0.0
     
@@ -213,7 +215,17 @@ class EmpireStatsWidget(Static):
         # Recent military events (placeholder)
         lines.append("")
         lines.append("Recent Activity:")
-        lines.append("  No recent military activity")
+        events = []
+        if self.event_manager and empire:
+            events = self.event_manager.get_recent_events(
+                empire.id, EventCategory.FLEET, limit=3
+            )
+
+        if events:
+            for event in events:
+                lines.append(f"  {event.title}")
+        else:
+            lines.append("  No recent military activity")
         
         text = '\n'.join(lines)
         

--- a/tests/test_empire_stats_widget.py
+++ b/tests/test_empire_stats_widget.py
@@ -24,3 +24,44 @@ def test_empire_age_calculation(monkeypatch):
 
     expected_age = format_time(100.0)
     assert f"Age: {expected_age}" in captured.get("text", "")
+
+
+def test_military_section_shows_recent_events(monkeypatch):
+    from pyaurora4x.core.events import EventManager, EventPriority, EventCategory, GameEvent, EventHandler
+
+    class DummyHandler(EventHandler):
+        def handle(self, event: GameEvent) -> bool:  # pragma: no cover - simple
+            return True
+
+    manager = EventManager()
+    manager.register_handler(DummyHandler(), EventCategory.FLEET)
+
+    empire = Empire(name="Test", home_system_id="sys", home_planet_id="planet")
+
+    manager.post_event(
+        GameEvent(
+            id="",
+            category=EventCategory.FLEET,
+            priority=EventPriority.NORMAL,
+            timestamp=1.0,
+            title="First Battle",
+            description="",
+            empire_id=empire.id,
+        )
+    )
+    manager.process_events()
+
+    widget = EmpireStatsWidget(event_manager=manager)
+    widget.current_empire = empire
+
+    captured = {}
+
+    class Dummy:
+        def update(self, text: str) -> None:
+            captured["text"] = text
+
+    monkeypatch.setattr(widget, "query_one", lambda *args, **kwargs: Dummy())
+
+    widget._update_military()
+
+    assert "First Battle" in captured.get("text", "")

--- a/tests/test_event_manager.py
+++ b/tests/test_event_manager.py
@@ -222,3 +222,39 @@ def test_event_expiration():
     assert log == []
     assert len(manager.processed_events) == 0
     assert len(manager.event_queue) == 0
+
+
+def test_get_recent_events():
+    manager = EventManager()
+    handler_log = []
+
+    manager.register_handler(RecordingHandler(handler_log), EventCategory.FLEET)
+
+    manager.post_event(
+        GameEvent(
+            id="",
+            category=EventCategory.FLEET,
+            priority=EventPriority.NORMAL,
+            timestamp=1,
+            title="old",
+            description="",
+            empire_id="emp",
+        )
+    )
+
+    manager.post_event(
+        GameEvent(
+            id="",
+            category=EventCategory.FLEET,
+            priority=EventPriority.NORMAL,
+            timestamp=2,
+            title="new",
+            description="",
+            empire_id="emp",
+        )
+    )
+
+    manager.process_events()
+
+    events = manager.get_recent_events("emp", EventCategory.FLEET, limit=1)
+    assert [e.title for e in events] == ["new"]


### PR DESCRIPTION
## Summary
- track recent processed events in `EventManager`
- inject an `EventManager` into `EmpireStatsWidget`
- list fleet events in the widget's military section
- expose the event manager from `GameSimulation` to the widget
- test retrieving recent events and displaying them in the widget

## Testing
- `pip install numpy "pydantic>=2.11.5" textual tinydb rebound duckdb pytest`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dab560fd48331aa2ba22dfc8d265a