### PR TITLE
Add new-game customization options

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,15 @@ You can also start a brand new game immediately with:
 python main.py --new-game
 ```
 
+You can customize the initial galaxy:
+
+```bash
+python main.py --new-game --systems 5 --empires 3
+```
+
+`--systems` controls how many star systems are generated, while `--empires`
+sets the total number of empires (including the player).
+
 This is useful when you want to skip loading existing saves and jump straight into a fresh session.
 
 To resume a previous session, provide the save name or path:

--- a/main.py
+++ b/main.py
@@ -64,9 +64,21 @@ def main():
         help="Load a saved game file"
     )
     parser.add_argument(
-        "--new-game", 
-        action="store_true", 
+        "--new-game",
+        action="store_true",
         help="Start a new game (default)"
+    )
+    parser.add_argument(
+        "--systems",
+        type=int,
+        default=3,
+        help="Number of star systems"
+    )
+    parser.add_argument(
+        "--empires",
+        type=int,
+        default=2,
+        help="Total empires (including player)"
     )
     
     args = parser.parse_args()
@@ -76,9 +88,12 @@ def main():
         return
     
     # Run the main Textual application
-    app = PyAurora4XApp()
+    app = PyAurora4XApp(
+        new_game_systems=args.systems,
+        new_game_empires=args.empires,
+    )
     
-    if args.load:
+    if args.load and not args.new_game:
         # Set load parameters for the app to handle after initialization
         save_manager = SaveManager()
         try:

--- a/pyaurora4x/ui/main_app.py
+++ b/pyaurora4x/ui/main_app.py
@@ -176,7 +176,7 @@ class PyAurora4XApp(App):
         Binding("h", "show_help", "Help"),
     ]
     
-    def __init__(self, **kwargs):
+    def __init__(self, new_game_systems: int = 3, new_game_empires: int = 2, **kwargs):
         super().__init__(**kwargs)
         self.simulation: Optional[GameSimulation] = None
         self.save_manager = SaveManager()
@@ -185,6 +185,8 @@ class PyAurora4XApp(App):
         self.last_auto_save = 0
         self.load_file: Optional[str] = None
         self.load_data: Optional[Dict[str, Any]] = None
+        self.new_game_systems = new_game_systems
+        self.new_game_empires = new_game_empires
     
     def compose(self) -> ComposeResult:
         """Compose the main application layout."""
@@ -231,7 +233,10 @@ class PyAurora4XApp(App):
     def start_new_game(self) -> None:
         """Start a new game."""
         self.simulation = GameSimulation()
-        self.simulation.initialize_new_game()
+        self.simulation.initialize_new_game(
+            num_systems=self.new_game_systems,
+            num_empires=self.new_game_empires,
+        )
         
         # Update UI components with new game data
         self._update_all_widgets()

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -301,4 +301,12 @@ class TestGameSimulation:
                 assert fleet.status == FleetStatus.IN_TRANSIT
                 assert fleet.estimated_arrival is not None
 
+    def test_custom_system_and_empire_counts(self):
+        """Initialize with custom counts and verify."""
+        sim = GameSimulation()
+        sim.initialize_new_game(num_systems=4, num_empires=4)
+
+        assert len(sim.star_systems) == 4
+        assert len(sim.empires) == 4
+
 


### PR DESCRIPTION
## Summary
- allow passing `--systems` and `--empires` on CLI
- wire new values through `PyAurora4XApp`
- document new command-line options
- test initializing with custom system and empire counts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dab508a8483319abd502ed1938f0a