### PR TITLE
Add fleet move dialog and update move logic

### DIFF
--- a/pyaurora4x/ui/widgets/__init__.py
+++ b/pyaurora4x/ui/widgets/__init__.py
@@ -9,6 +9,7 @@ from pyaurora4x.ui.widgets.fleet_panel import FleetPanel
 from pyaurora4x.ui.widgets.research_panel import ResearchPanel
 from pyaurora4x.ui.widgets.empire_stats import EmpireStatsWidget
 from pyaurora4x.ui.widgets.load_dialog import LoadGameDialog
+from pyaurora4x.ui.widgets.planet_select_dialog import PlanetSelectDialog
 
 __all__ = [
     "StarSystemView",
@@ -16,4 +17,5 @@ __all__ = [
     "ResearchPanel",
     "EmpireStatsWidget",
     "LoadGameDialog",
+    "PlanetSelectDialog",
 ]

--- a/pyaurora4x/ui/widgets/planet_select_dialog.py
+++ b/pyaurora4x/ui/widgets/planet_select_dialog.py
@@ -1,0 +1,35 @@
+from typing import Callable, List
+
+from textual.app import ComposeResult
+from textual.widgets import Static, OptionList, Button
+from textual.widgets._option_list import Option
+from textual.containers import Vertical
+
+from pyaurora4x.core.models import Planet
+
+
+class PlanetSelectDialog(Static):
+    """Modal dialog for selecting a destination planet."""
+
+    def __init__(self, planets: List[Planet], on_select: Callable[[str], None], **kwargs):
+        super().__init__(**kwargs)
+        self.planets = planets
+        self.on_select = on_select
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="planet_select_dialog"):
+            yield Static("Select Destination", id="planet_select_title")
+            option_list = OptionList(id="planet_options")
+            for planet in self.planets:
+                option_list.add_option(Option(planet.name, id=planet.id))
+            yield option_list
+            yield Button("Cancel", id="cancel_planet_select")
+
+    def on_option_list_option_selected(self, event: OptionList.OptionSelected) -> None:  # type: ignore[override]
+        if self.on_select and event.option.id is not None:
+            self.on_select(event.option.id)
+        self.remove()
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:  # type: ignore[override]
+        if event.button.id == "cancel_planet_select":
+            self.remove()

--- a/tests/test_fleet_panel.py
+++ b/tests/test_fleet_panel.py
@@ -1,6 +1,16 @@
 from pyaurora4x.ui.widgets.fleet_panel import FleetPanel
-from pyaurora4x.core.models import Fleet, Vector3D
-from pyaurora4x.core.enums import FleetStatus
+from pyaurora4x.ui.widgets.planet_select_dialog import PlanetSelectDialog
+from pyaurora4x.core.models import (
+    Fleet,
+    Vector3D,
+    Planet,
+    StarSystem,
+)
+from pyaurora4x.core.enums import FleetStatus, PlanetType, StarType
+from pyaurora4x.engine.orbital_mechanics import OrbitalMechanics
+from textual.widgets._option_list import Option
+from textual.widgets import OptionList
+from pyaurora4x.ui.widgets.fleet_panel import FleetCommandEvent
 from pyaurora4x.core.utils import format_time
 
 
@@ -35,3 +45,100 @@ def test_generate_fleet_details_overdue_eta():
     fleet = create_fleet("Beta", 800.0)
     result = panel._generate_fleet_details(fleet, current_time=1000.0)
     assert "ETA: 0.0s" in result
+
+
+def test_planet_select_dialog_callback():
+    selected: list[str] = []
+    planet_a = Planet(
+        name="A",
+        planet_type=PlanetType.TERRESTRIAL,
+        mass=1.0,
+        radius=1.0,
+        surface_temperature=288.0,
+        orbital_distance=1.0,
+        orbital_period=1.0,
+        position=Vector3D(x=1000, y=0, z=0),
+    )
+    planet_b = Planet(
+        name="B",
+        planet_type=PlanetType.TERRESTRIAL,
+        mass=1.0,
+        radius=1.0,
+        surface_temperature=288.0,
+        orbital_distance=1.5,
+        orbital_period=2.0,
+        position=Vector3D(x=2000, y=0, z=0),
+    )
+    dialog = PlanetSelectDialog([planet_a, planet_b], lambda pid: selected.append(pid))
+    dialog.remove = lambda: None  # Avoid NoActiveAppError during tests
+    option = Option(planet_b.name, id=planet_b.id)
+    event = OptionList.OptionSelected(OptionList(), option, 1)
+    dialog.on_option_list_option_selected(event)
+    assert selected == [planet_b.id]
+
+
+class DummyApp:
+    def __init__(self, simulation):
+        self.simulation = simulation
+
+
+class TestMoveFleet:
+    def test_apply_move_selection_updates_fleet(self):
+        panel = DummyFleetPanel()
+        panel.posted = None
+        def post_message(event):
+            panel.posted = event
+        panel.post_message_no_wait = post_message  # type: ignore
+
+        planet_a = Planet(
+            name="A",
+            planet_type=PlanetType.TERRESTRIAL,
+            mass=1.0,
+            radius=1.0,
+            surface_temperature=288.0,
+            orbital_distance=1.0,
+            orbital_period=1.0,
+            position=Vector3D(x=1000, y=0, z=0),
+        )
+        planet_b = Planet(
+            name="B",
+            planet_type=PlanetType.TERRESTRIAL,
+            mass=1.0,
+            radius=1.0,
+            surface_temperature=288.0,
+            orbital_distance=1.5,
+            orbital_period=2.0,
+            position=Vector3D(x=2000, y=0, z=0),
+        )
+        system = StarSystem(
+            name="Sys",
+            star_type=StarType.G_DWARF,
+            star_mass=1.0,
+            star_luminosity=1.0,
+            planets=[planet_a, planet_b],
+        )
+        fleet = Fleet(
+            name="Fleet",
+            empire_id="emp",
+            system_id=system.id,
+            position=planet_a.position.copy(),
+        )
+        simulation = type(
+            "Sim",
+            (),
+            {
+                "star_systems": {system.id: system},
+                "orbital_mechanics": OrbitalMechanics(),
+                "current_time": 0.0,
+            },
+        )()
+
+        panel._apply_move_selection(fleet, planet_b, system, simulation)
+
+        assert fleet.destination == planet_b.position
+        assert fleet.estimated_arrival and fleet.estimated_arrival > 0
+        assert fleet.current_orders and "Transfer to" in fleet.current_orders[-1]
+        assert fleet.status == FleetStatus.IN_TRANSIT
+        assert isinstance(panel.posted, FleetCommandEvent)
+        assert panel.posted.command == "move"
+        assert panel.posted.fleet_id == fleet.id


### PR DESCRIPTION
## Summary
- add `PlanetSelectDialog` for choosing a destination planet
- integrate new dialog into `FleetPanel` move logic with `_apply_move_selection`
- export `PlanetSelectDialog` for external use
- update unit tests for new dialog and fleet move behaviour

## Testing
- `pip install numpy "pydantic>=2.11.5" textual tinydb rebound duckdb pytest`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dab53e31c8331b937e4150bedcb41