### PR TITLE
Add Streamlit dashboard example

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ contribute new documents.
 - [docs/gameplay_guide.md](docs/gameplay_guide.md) – How to play: basic commands, UI overview, gameplay phases, and fleet movement details.
 - [docs/contributing.md](docs/contributing.md) – Developer contribution guide.
 - [docs/game_turns.md](docs/game_turns.md) – Overview of the turn and tick system.
+- [docs/streamlit_dashboard.md](docs/streamlit_dashboard.md) – How to launch the Streamlit dashboard.
 
 
 ## License

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ for documentation and as a guide when adding new files.
 - [Gameplay Guide](gameplay_guide.md) – Basic commands, UI overview, and gameplay phases. Lists keyboard shortcuts like the `F1`–`F5` fleet focus keys.
 - [Contribution Guide](contributing.md)
 - [Game Turns](game_turns.md) – Explanation of the turn/tick system.
+- [Streamlit Dashboard](streamlit_dashboard.md) – Launch a Streamlit dashboard to inspect game data.
 
 
 ## Contributing New Documentation

--- a/docs/streamlit_dashboard.md
+++ b/docs/streamlit_dashboard.md
@@ -1,0 +1,22 @@
+# Streamlit Dashboard
+
+This document explains how to launch a simple Streamlit dashboard for inspecting a generated PyAurora 4X game state.
+
+The dashboard displays star systems, sample ships and empire information using tabs. It relies on the `streamlit_dashboard.py` script at the project root which builds a small game using `GameSimulation`.
+
+## Running the Dashboard
+
+1. Install the required package:
+
+```bash
+pip install streamlit
+```
+
+2. Run the application from the repository root:
+
+```bash
+streamlit run streamlit_dashboard.py
+```
+
+The dashboard will open in your browser. Use the sidebar to switch between Worlds, Ships and Empires views.
+

--- a/streamlit_dashboard.py
+++ b/streamlit_dashboard.py
@@ -1,0 +1,86 @@
+import streamlit as st
+from pyaurora4x.engine.simulation import GameSimulation
+from pyaurora4x.core.models import Ship
+
+@st.cache_resource
+def get_simulation():
+    sim = GameSimulation()
+    sim.initialize_new_game(num_systems=3, num_empires=2)
+    # Create a few sample ships for the player's first fleet
+    player = sim.get_player_empire()
+    ships = {}
+    if player and player.fleets:
+        fleet = sim.get_fleet(player.fleets[0])
+        if fleet:
+            for i in range(3):
+                ship = Ship(
+                    name=f"Ship {i+1}",
+                    design_id="basic",
+                    empire_id=player.id,
+                    fleet_id=fleet.id,
+                )
+                fleet.ships.append(ship.id)
+                ships[ship.id] = ship
+    return sim, ships
+
+sim, ships = get_simulation()
+
+st.title("PyAurora 4X Dashboard")
+
+view = st.sidebar.selectbox("View", ["Worlds", "Ships", "Empires"])
+
+if view == "Worlds":
+    systems = list(sim.star_systems.values())
+    if not systems:
+        st.write("No star systems available.")
+    else:
+        idx = st.selectbox(
+            "Star System",
+            range(len(systems)),
+            format_func=lambda i: systems[i].name,
+        )
+        system = systems[idx]
+        st.subheader(system.name)
+        st.write(f"Star Type: {system.star_type}")
+        st.write(f"Planets: {len(system.planets)}")
+        for planet in system.planets:
+            st.markdown(f"**{planet.name}** - {planet.planet_type}")
+            st.write(f"Orbit: {planet.orbital_distance:.2f} AU")
+        if system.asteroid_belts:
+            st.write("Asteroid Belts:")
+            for belt in system.asteroid_belts:
+                st.write(f"- {belt.distance:.2f} AU width {belt.width:.2f} AU")
+elif view == "Ships":
+    if not ships:
+        st.write("No ships available.")
+    else:
+        ids = list(ships.keys())
+        ship_id = st.selectbox(
+            "Ship",
+            ids,
+            format_func=lambda sid: ships[sid].name,
+        )
+        ship = ships[ship_id]
+        st.subheader(ship.name)
+        st.write(f"Design: {ship.design_id}")
+        st.write(f"Fleet ID: {ship.fleet_id}")
+        st.write(f"Empire: {sim.empires[ship.empire_id].name}")
+        st.write(f"Fuel: {ship.fuel}")
+        st.write(f"Condition: {ship.condition}")
+elif view == "Empires":
+    ids = list(sim.empires.keys())
+    if not ids:
+        st.write("No empires found.")
+    else:
+        empire_id = st.selectbox(
+            "Empire",
+            ids,
+            format_func=lambda eid: sim.empires[eid].name,
+        )
+        empire = sim.empires[empire_id]
+        st.subheader(empire.name)
+        st.write(f"Home System: {sim.star_systems[empire.home_system_id].name}")
+        st.write(f"Colonies: {len(empire.colonies)}")
+        st.write(f"Fleets: {len(empire.fleets)}")
+        st.write(f"Resources: {empire.resources}")
+


### PR DESCRIPTION
## Summary
- add example `streamlit_dashboard.py` that builds a small game and displays data using Streamlit
- document how to run the dashboard
- link new documentation from README files

## Testing
- `pip install numpy "pydantic>=2.11.5" textual tinydb rebound duckdb pytest streamlit`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e02947eb0833187f73cccc1aa3be7