### PR TITLE
Add basic colony management

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A Python-based 4X space strategy game with realistic orbital mechanics, terminal
 - **Research System**: Technology tree with prerequisites and unlocks
 - **Fleet Management**: Design ships, manage fleets, and conduct space operations
 - **Save/Load System**: Persistent game states with TinyDB and JSON support
+- **Colony Management**: Colonies grow and produce resources over time
 - **Comprehensive Testing**: Full test coverage with pytest
 
 ## Installation
@@ -138,6 +139,7 @@ contribute new documents.
 - [docs/game_turns.md](docs/game_turns.md) – Overview of the turn and tick system.
 - [docs/streamlit_dashboard.md](docs/streamlit_dashboard.md) – How to launch the Streamlit dashboard.
 - [docs/jump_points.md](docs/jump_points.md) – Details on jump point mechanics and FTL travel.
+- [docs/colony_management.md](docs/colony_management.md) – Overview of colony growth and resource production.
 
 
 ## License

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ for documentation and as a guide when adding new files.
 - [Contribution Guide](contributing.md)
 - [Game Turns](game_turns.md) – Explanation of the turn/tick system.
 - [Streamlit Dashboard](streamlit_dashboard.md) – Launch a Streamlit dashboard to inspect game data.
+- [Colony Management](colony_management.md) – Population growth and mining basics.
 
 
 ## Contributing New Documentation

--- a/docs/colony_management.md
+++ b/docs/colony_management.md
@@ -1,0 +1,10 @@
+# Colony Management
+
+PyAurora 4X now includes a simple colony management system. Each empire starts
+with a colony on its homeworld. Colonies track population, basic
+infrastructure and local stockpiles.
+
+During time advancement colonies grow based on their `growth_rate` and produce
+minerals from any `mine` infrastructure. The production is added directly to the
+colony stockpiles. These mechanics provide the foundation for future industry
+and economy features.

--- a/tests/test_colony_management.py
+++ b/tests/test_colony_management.py
@@ -1,0 +1,25 @@
+from pyaurora4x.engine.simulation import GameSimulation
+
+
+def test_colony_initialization():
+    sim = GameSimulation()
+    sim.initialize_new_game(num_systems=2, num_empires=2)
+
+    total_colonies = sum(len(emp.colonies) for emp in sim.empires.values())
+    assert total_colonies == len(sim.colonies)
+    assert total_colonies == len(sim.empires)
+
+
+def test_colony_growth_and_mining():
+    sim = GameSimulation()
+    sim.initialize_new_game(num_systems=1, num_empires=1)
+    empire = sim.get_player_empire()
+    colony_id = empire.colonies[0]
+    colony = sim.colonies[colony_id]
+    colony.population = 1000
+    colony.infrastructure["mine"] = 1
+
+    sim.advance_time(86400)  # one day
+
+    assert colony.population > 1000
+    assert colony.stockpiles.get("minerals", 0) > 0

--- a/tests/test_fleet_panel.py
+++ b/tests/test_fleet_panel.py
@@ -20,6 +20,9 @@ class DummyFleetPanel(FleetPanel):
     def refresh(self, *args, **kwargs):  # type: ignore[override]
         pass
 
+    def refresh_fleet_data(self) -> None:  # type: ignore[override]
+        pass
+
 
 def create_fleet(name: str, arrival: float) -> Fleet:
     return Fleet(


### PR DESCRIPTION
## Summary
- implement colony objects and link to empires
- update colonies each tick for growth and mining
- persist colonies in save games
- document colony features and mention them in README
- tweak fleet panel tests for new refresh method
- add tests for colony management

## Testing
- `pip install numpy "pydantic>=2.11.5" textual tinydb rebound duckdb pytest`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685587a802e48331b6bd82f84467499e