### PR TITLE
Implement basic fleet combat

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ contribute new documents.
 - [docs/streamlit_dashboard.md](docs/streamlit_dashboard.md) – How to launch the Streamlit dashboard.
 - [docs/jump_points.md](docs/jump_points.md) – Details on jump point mechanics and FTL travel.
 - [docs/colony_management.md](docs/colony_management.md) – Overview of colony growth and resource production.
+- [docs/fleet_combat.md](docs/fleet_combat.md) – Overview of combat and command features.
 
 
 ## License

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ for documentation and as a guide when adding new files.
 - [Game Turns](game_turns.md) – Explanation of the turn/tick system.
 - [Streamlit Dashboard](streamlit_dashboard.md) – Launch a Streamlit dashboard to inspect game data.
 - [Colony Management](colony_management.md) – Population growth and mining basics.
+- [Fleet Combat and Command](fleet_combat.md) – Overview of combat resolution and officer mechanics.
 
 
 ## Contributing New Documentation

--- a/docs/fleet_combat.md
+++ b/docs/fleet_combat.md
@@ -1,0 +1,20 @@
+# Fleet Combat and Command Structure
+
+This document outlines the early combat mechanics for **PyAurora 4X**.
+
+## Tactical Engagements
+
+Fleets can engage each other directly. The `GameSimulation.start_combat`
+method resolves a basic battle by comparing the number of ships in each
+fleet. The side with the larger force wins and both fleets return to the
+`IDLE` status afterward.
+
+These rules provide a placeholder system that will be expanded with
+weapon damage, ship roles and commander bonuses in future updates.
+
+## Officers and Ship Roles
+
+Ships now include a `role` attribute describing their duty within the
+fleet such as `command`, `assault`, or `support`. Fleets may have a
+`commander_id` and a list of assigned officers. Officers track rank and
+experience but currently provide no modifiers.

--- a/pyaurora4x/core/__init__.py
+++ b/pyaurora4x/core/__init__.py
@@ -14,6 +14,7 @@ from pyaurora4x.core.models import (
     Vector3D,
     AsteroidBelt,
     Technology,
+    Officer,
 )
 from pyaurora4x.core.enums import (
     PlanetType,
@@ -21,6 +22,8 @@ from pyaurora4x.core.enums import (
     FleetStatus,
     TechnologyType,
     ShipType,
+    ShipRole,
+    OfficerRank,
 )
 from pyaurora4x.core.events import EventManager, GameEvent
 from pyaurora4x.core.utils import distance_3d, angle_between_vectors
@@ -35,11 +38,14 @@ __all__ = [
     "AsteroidBelt",
     "Vector3D",
     "Technology",
+    "Officer",
     "PlanetType",
     "StarType",
     "FleetStatus",
     "TechnologyType",
     "ShipType",
+    "ShipRole",
+    "OfficerRank",
     "EventManager",
     "GameEvent",
     "distance_3d",

--- a/pyaurora4x/core/enums.py
+++ b/pyaurora4x/core/enums.py
@@ -83,6 +83,27 @@ class ShipType(Enum):
     REPAIR_SHIP = "repair_ship"
 
 
+class ShipRole(Enum):
+    """Functional role of a ship within a fleet."""
+
+    COMMAND = "command"
+    ASSAULT = "assault"
+    SUPPORT = "support"
+    SCOUT = "scout"
+    TRANSPORT = "transport"
+    SURVEY = "survey"
+    MINER = "miner"
+
+
+class OfficerRank(Enum):
+    """Ranks for naval officers."""
+
+    CAPTAIN = "captain"
+    COMMANDER = "commander"
+    COMMODORE = "commodore"
+    ADMIRAL = "admiral"
+
+
 class ComponentType(Enum):
     """Types of ship components."""
     ENGINE = "engine"

--- a/pyaurora4x/core/models.py
+++ b/pyaurora4x/core/models.py
@@ -15,6 +15,8 @@ from pyaurora4x.core.enums import (
     FleetStatus,
     TechnologyType,
     ShipType,
+    ShipRole,
+    OfficerRank,
 )
 
 
@@ -104,6 +106,17 @@ class Ship(BaseModel):
     # Orders and AI
     current_orders: List[str] = Field(default_factory=list)
     automation_enabled: bool = False
+    role: ShipRole = ShipRole.SUPPORT
+
+
+class Officer(BaseModel):
+    """Represents a fleet officer."""
+
+    id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    name: str
+    rank: OfficerRank = OfficerRank.CAPTAIN
+    experience: float = 0.0
+    assigned_fleet_id: Optional[str] = None
 
 
 class Fleet(BaseModel):
@@ -120,6 +133,8 @@ class Fleet(BaseModel):
 
     # Fleet composition
     ships: List[str] = Field(default_factory=list)  # Ship IDs
+    commander_id: Optional[str] = None
+    officers: List[str] = Field(default_factory=list)
 
     # Status and orders
     status: FleetStatus = FleetStatus.IDLE

--- a/pyaurora4x/engine/simulation.py
+++ b/pyaurora4x/engine/simulation.py
@@ -443,6 +443,37 @@ class GameSimulation:
         fleet.estimated_arrival = None
         fleet.status = FleetStatus.IDLE
         return True
+
+    def start_combat(self, attacker_id: str, defender_id: str) -> Optional[str]:
+        """Resolve a simple combat between two fleets.
+
+        The fleet with the greater number of ships is declared the winner.
+
+        Args:
+            attacker_id: Attacking fleet ID.
+            defender_id: Defending fleet ID.
+
+        Returns:
+            The winning fleet ID, or ``None`` if combat could not start.
+        """
+        attacker = self.get_fleet(attacker_id)
+        defender = self.get_fleet(defender_id)
+        if not attacker or not defender:
+            return None
+
+        attacker.status = FleetStatus.IN_COMBAT
+        defender.status = FleetStatus.IN_COMBAT
+
+        attacker_strength = len(attacker.ships)
+        defender_strength = len(defender.ships)
+
+        winner = attacker if attacker_strength >= defender_strength else defender
+        loser = defender if winner is attacker else attacker
+
+        winner.status = FleetStatus.IDLE
+        loser.status = FleetStatus.IDLE
+
+        return winner.id
     
     def get_game_state(self) -> Dict[str, Any]:
         """Get the current game state for saving."""

--- a/tests/test_combat.py
+++ b/tests/test_combat.py
@@ -1,0 +1,25 @@
+import pytest
+from pyaurora4x.engine.simulation import GameSimulation
+from pyaurora4x.core.enums import FleetStatus
+from pyaurora4x.core.models import Fleet, Vector3D
+
+
+def test_start_combat():
+    sim = GameSimulation()
+    sim.initialize_new_game(num_systems=2, num_empires=2)
+
+    system_id = list(sim.star_systems.keys())[0]
+    attacker = Fleet(name="Attacker", empire_id="player", system_id=system_id, position=Vector3D())
+    ai_id = next(eid for eid in sim.empires if eid != "player")
+    defender = Fleet(name="Defender", empire_id=ai_id, system_id=system_id, position=Vector3D())
+
+    attacker.ships = ["s1", "s2"]
+    defender.ships = ["s3"]
+
+    sim.fleets[attacker.id] = attacker
+    sim.fleets[defender.id] = defender
+
+    winner = sim.start_combat(attacker.id, defender.id)
+    assert winner in (attacker.id, defender.id)
+    assert sim.fleets[attacker.id].status == FleetStatus.IDLE
+    assert sim.fleets[defender.id].status == FleetStatus.IDLE

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -9,7 +9,11 @@ from pyaurora4x.core.models import (
     Vector3D, Empire, Fleet, Ship, Colony, StarSystem, Planet, Technology
 )
 from pyaurora4x.core.enums import (
-    PlanetType, StarType, FleetStatus, TechnologyType
+    PlanetType,
+    StarType,
+    FleetStatus,
+    TechnologyType,
+    ShipRole,
 )
 
 
@@ -277,6 +281,7 @@ class TestShip:
         assert ship.fuel == 100.0
         assert ship.condition == 100.0
         assert ship.structure == 100.0
+        assert ship.role == ShipRole.SUPPORT
     
     def test_ship_defaults(self):
         """Test ship default values."""
@@ -292,6 +297,7 @@ class TestShip:
         assert ship.armor == 0.0
         assert len(ship.current_orders) == 0
         assert not ship.automation_enabled
+        assert ship.role == ShipRole.SUPPORT
 
 
 class TestColony:


### PR DESCRIPTION
## Summary
- add `ShipRole` and `OfficerRank` enums
- expand ship and fleet models with roles, commanders, and officers
- introduce an `Officer` model
- implement a simple `start_combat` method
- document combat and command structure
- test new models and combat logic

## Testing
- `pytest tests/test_combat.py::test_start_combat -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68558c28a91c8331957956b21065f27d