### PR TITLE
Add multi-project research system

### DIFF
--- a/pyaurora4x/core/models.py
+++ b/pyaurora4x/core/models.py
@@ -274,6 +274,8 @@ class Empire(BaseModel):
     technologies: Dict[str, Technology] = Field(default_factory=dict)
     current_research: Optional[str] = None
     research_points: float = 0.0
+    research_projects: Dict[str, float] = Field(default_factory=dict)
+    research_labs: int = 1
     research_allocation: Dict[TechnologyType, float] = Field(default_factory=dict)
 
     # Resources and economy

--- a/pyaurora4x/ui/widgets/__init__.py
+++ b/pyaurora4x/ui/widgets/__init__.py
@@ -10,6 +10,7 @@ from pyaurora4x.ui.widgets.research_panel import ResearchPanel
 from pyaurora4x.ui.widgets.empire_stats import EmpireStatsWidget
 from pyaurora4x.ui.widgets.load_dialog import LoadGameDialog
 from pyaurora4x.ui.widgets.planet_select_dialog import PlanetSelectDialog
+from pyaurora4x.ui.widgets.ship_design_panel import ShipDesignPanel
 
 __all__ = [
     "StarSystemView",
@@ -18,4 +19,5 @@ __all__ = [
     "EmpireStatsWidget",
     "LoadGameDialog",
     "PlanetSelectDialog",
+    "ShipDesignPanel",
 ]

--- a/pyaurora4x/ui/widgets/ship_design_panel.py
+++ b/pyaurora4x/ui/widgets/ship_design_panel.py
@@ -1,0 +1,68 @@
+"""Ship Design Panel Widget.
+
+Provides a simple interface for creating ship designs from available
+components. This is an early stub implementation and only supports
+basic functionality."""
+
+from typing import List, Optional
+from textual.widgets import Static, DataTable, Button, Label
+from textual.containers import Vertical, Horizontal, Container
+from textual.app import ComposeResult
+
+from pyaurora4x.core.models import Empire, ShipDesign, ShipComponent
+from pyaurora4x.data.ship_components import ShipComponentManager
+
+
+class ShipDesignPanel(Static):
+    """Widget for managing ship designs."""
+
+    def __init__(self, component_manager: ShipComponentManager, **kwargs):
+        super().__init__(**kwargs)
+        self.component_manager = component_manager
+        self.empire: Optional[Empire] = None
+        self.selected_components: List[str] = []
+
+    def compose(self) -> ComposeResult:
+        with Container(id="design_container"):
+            with Horizontal():
+                with Vertical(id="component_list"):
+                    yield Label("Components")
+                    yield DataTable(id="component_table")
+                with Vertical(id="design_controls"):
+                    yield Label("Selected Components")
+                    yield DataTable(id="selected_table")
+                    yield Button("Create Design", id="create_design", variant="primary")
+
+    def on_mount(self) -> None:
+        table = self.query_one("#component_table", DataTable)
+        table.add_columns("Component", "Type")
+        for comp in self.component_manager.components.values():
+            table.add_row(comp.name, comp.component_type, key=comp.id)
+
+        sel_table = self.query_one("#selected_table", DataTable)
+        sel_table.add_columns("Component", "Type")
+
+    def on_data_table_row_selected(self, event: DataTable.RowSelected) -> None:
+        if event.data_table.id == "component_table":
+            comp_id = event.row_key
+            if comp_id not in self.selected_components:
+                self.selected_components.append(comp_id)
+                comp = self.component_manager.get_component(comp_id)
+                sel = self.query_one("#selected_table", DataTable)
+                sel.add_row(comp.name, comp.component_type, key=comp.id)
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "create_design" and self.empire:
+            design_id = f"design_{len(self.empire.ship_designs)}"
+            design = self.component_manager.create_ship_design(
+                design_id,
+                design_id.title(),
+                ShipDesign.model_fields['ship_type'].default,
+                self.selected_components,
+            )
+            if design:
+                self.empire.ship_designs.append(design.id)
+                self.selected_components.clear()
+                sel = self.query_one("#selected_table", DataTable)
+                sel.clear()
+

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -247,6 +247,8 @@ class TestEmpire:
         assert len(empire.fleets) == 0
         assert len(empire.colonies) == 0
         assert empire.research_points == 0.0
+        assert empire.research_labs == 1
+        assert len(empire.research_projects) == 0
         assert empire.government_type == "Democracy"
         assert empire.culture == "Human"
     

--- a/tests/test_research.py
+++ b/tests/test_research.py
@@ -18,6 +18,24 @@ def test_research_completion():
     assert empire.current_research is None
 
 
+def test_multiple_research_projects():
+    sim = GameSimulation()
+    sim.initialize_new_game(num_systems=1, num_empires=1)
+    empire = sim.get_player_empire()
+    empire.research_labs = 2
+
+    tech1 = empire.technologies["basic_propulsion"]
+    tech2 = empire.technologies["basic_sensors"]
+
+    empire.current_research = tech1.id
+    empire.research_projects[tech2.id] = 0.0
+
+    sim.advance_time(max(tech1.research_cost, tech2.research_cost))
+
+    assert tech1.is_researched
+    assert tech2.is_researched
+
+
 def test_research_persistence(tmp_path):
     sim = GameSimulation()
     sim.initialize_new_game(num_systems=1, num_empires=1)

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -294,7 +294,10 @@ class TestGameSimulation:
 
         for empire in ai_empires:
             # Should have started some research
-            assert empire.current_research is not None
+            active = (
+                1 if empire.current_research else 0
+            ) + len(empire.research_projects)
+            assert active > 0
 
             for fleet_id in empire.fleets:
                 fleet = sim.get_fleet(fleet_id)


### PR DESCRIPTION
## Summary
- allow empires to manage multiple research projects
- show all active research in the UI
- add simple ship design panel widget
- adjust AI research behavior and tests

## Testing
- `pip install numpy "pydantic>=2.11.5" textual tinydb rebound duckdb pytest`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855eed3eed08331a62b4b414d174993