### PR TITLE
Add jump points doc link to docs index

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ for documentation and as a guide when adding new files.
 - [Contribution Guide](contributing.md)
 - [Game Turns](game_turns.md) – Explanation of the turn/tick system.
 - [Streamlit Dashboard](streamlit_dashboard.md) – Launch a Streamlit dashboard to inspect game data.
+- [Jump Points](jump_points.md) – Details on jump point mechanics and FTL travel.
 - [Colony Management](colony_management.md) – Population growth and mining basics.
 - [Fleet Combat and Command](fleet_combat.md) – Overview of combat resolution and officer mechanics.
 


### PR DESCRIPTION
## Summary
- add an entry for `jump_points.md` in the docs table of contents

## Testing
- `pip install numpy "pydantic>=2.11.5" textual tinydb rebound duckdb pytest`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687005ef11688331b181514234447ecc